### PR TITLE
Exclude additional FIPS related test failures

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -117,6 +117,7 @@ com/sun/crypto/provider/Cipher/RSA/TestOAEPParameterSpec.java https://github.com
 com/sun/crypto/provider/Cipher/RSA/TestOAEPWithParams.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/RSA/TestOAEP_KAT.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/RSA/TestRSA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/Cipher/Test4958071.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/TextLength/SameBufferOverwrite.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/TextLength/TestCipherTextLength.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/UTIL/StrongOrUnlimited.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -141,6 +142,7 @@ com/sun/crypto/provider/KeyFactory/TestProviderLeak.java https://github.com/ecli
 com/sun/crypto/provider/KeyGenerator/Test4628062.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/KeyGenerator/Test6227536.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/KeyGenerator/TestExplicitKeyLength.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/KeyProtector/IterationCount.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Mac/DigestCloneabilityTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Mac/EmptyByteBufferTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Mac/HmacMD5.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -152,6 +154,7 @@ com/sun/crypto/provider/Mac/MacClone.java https://github.com/eclipse-openj9/open
 com/sun/crypto/provider/Mac/MacKAT.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Mac/MacSameTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Mac/NullByteBufferTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/Mac/Test6205692.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/NSASuiteB/TestAESOids.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/NSASuiteB/TestAESWrapOids.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/NSASuiteB/TestHmacSHAOids.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -208,7 +211,7 @@ java/security/MessageDigest/TestDigestIOStream.java https://github.com/eclipse-o
 java/security/MessageDigest/TestSameLength.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/MessageDigest/TestSameValue.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Policy/ExtensiblePolicy/ExtensiblePolicyTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-java/security/Policy/ExtensiblePolicy/ExtensiblePolicyWithJarTest.java https://github.ibm.com/runtimes/jit-crypto/issues/622 generic-all
+java/security/Policy/ExtensiblePolicy/ExtensiblePolicyWithJarTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Policy/GetInstance/GetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Policy/GetInstance/GetInstanceSecurity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Policy/SignedJar/SignedJarTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -281,6 +284,7 @@ java/security/cert/CertPathValidator/trustAnchor/ValWithAnchorByName.java https:
 java/security/cert/CertPathValidatorException/Serial.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/CertificateRevokedException/Basic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/GetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/cert/PKIXRevocationChecker/OcspUnauthorized.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/PKIXRevocationChecker/UnitTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/PolicyNode/GetPolicyQualifiers.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/cert/X509CRL/VerifyDefault.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -299,7 +303,7 @@ javax/crypto/Cipher/TestCipherMode.java https://github.com/eclipse-openj9/openj9
 javax/crypto/Cipher/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Cipher/Turkish.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CipherSpi/DirectBBRemaining.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/crypto/CipherSpi/ResetByteBuffer.java https://github.com/eclipse-openj9/openj9/issues/20343 linux-s390x,windows-all
+javax/crypto/CipherSpi/ResetByteBuffer.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermission/AllPermCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermission/LowercasePermCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermission/RC2PermCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -329,6 +333,7 @@ javax/crypto/spec/DESKeySpec/CheckParity.java https://github.com/eclipse-openj9/
 javax/crypto/spec/RC2ParameterSpec/RC2AlgorithmParameters.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/kerberos/KerberosTixDateTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/security/auth/kerberos/StandardNames.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/security/auth/Subject/UnsupportedSV.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/BadXPointer.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/Basic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/xml/crypto/dsig/ErrorHandlerPermissions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -432,8 +437,8 @@ sun/security/krb5/auto/UnboundService.java https://github.com/eclipse-openj9/ope
 sun/security/krb5/auto/UseCacheAndStoreKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/auto/W83.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/krb5/auto/tools/KinitConfPlusProps.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/krb5/auto/tools/KtabSalt.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
+sun/security/krb5/auto/tools/KinitConfPlusProps.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/krb5/auto/tools/KtabSalt.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/etype/KerberosAesSha2.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/etype/WeakCrypto.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/krb5/ktab/BufferBoundary.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -472,7 +477,7 @@ java/rmi/MarshalledObject/MOFilterTest.java https://github.com/eclipse-openj9/op
 java/rmi/MarshalledObject/compare/Compare.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/MarshalledObject/compare/HashCode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/DefaultRegistryPort.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-java/rmi/Naming/LookupIPv6.java https://github.com/eclipse-openj9/openj9/issues/20343 aix-all,linux-ppc64le,linux-s390x,windows-all
+java/rmi/Naming/LookupIPv6.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/LookupNameWithColon.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/RmiIsNoScheme.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/rmi/Naming/UnderscoreHost.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -539,6 +544,7 @@ java/sql/testng/test/sql/SQLTransientExceptionTests.java https://github.com/ecli
 java/sql/testng/test/sql/SQLWarningTests.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/naming/module/RunBasic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/naming/spi/FactoryCacheTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+javax/naming/spi/providers/InitialContextTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 javax/net/ssl/ALPN/SSLEngineAlpnTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ALPN/SSLServerSocketAlpnTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ALPN/SSLSocketAlpnTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -627,8 +633,8 @@ javax/net/ssl/ServerName/EndingDotHostname.java https://github.com/eclipse-openj
 javax/net/ssl/ServerName/SSLEngineExplorer.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLSocketConsistentSNI.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLSocketExplorer.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLSocketExplorerFailure.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -738,6 +744,9 @@ javax/xml/jaxp/datatype/8033980/SerializationTest.java https://github.com/eclips
 jdk/dynalink/BeanLinkerTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 jdk/dynalink/TrustedDynamicLinkerFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 jdk/dynalink/UntrustedDynamicLinkerFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+jdk/internal/jline/JLineConsoleProviderTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+jdk/internal/jline/LazyJdkConsoleProvider.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+jdk/internal/jline/RedirectedStdOut.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 jdk/security/jarsigner/Function.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 jdk/security/jarsigner/JarWithOneNonDisabledDigestAlg.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 jdk/security/jarsigner/Properties.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -779,20 +788,21 @@ sun/security/ec/xec/TestXDH.java https://github.com/eclipse-openj9/openj9/issues
 sun/security/ec/xec/XECKeyFormat.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/jca/PreferredProviderNegativeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/jca/PreferredProviderTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/mscapi/AccessKeyStore.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/AllTypes.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/DupAlias.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/EncodingMutability.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/IsSunMSCAPIAvailable.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/IterateWindowsRootStore.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/KeyStoreCompatibilityMode.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/KeytoolChangeAlias.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/NullKey.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/PrngSerialize.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
-sun/security/mscapi/PrngSlow.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
+sun/security/mscapi/AccessKeyStore.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/AllTypes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/DupAlias.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/EncodingMutability.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/IsSunMSCAPIAvailable.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/IterateWindowsRootStore.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/KeyStoreCompatibilityMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/KeytoolChangeAlias.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/NullKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/PrngSerialize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/mscapi/PrngSlow.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs10/PKCS10AttrEncoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs7/PKCS7VerifyTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs7/SignerOrder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs/pkcs8/LongPKCS8orX509KeySpec.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs8/PKCS8Test.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs8/TestLeadingZeros.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs9/PKCS9AttrTypeTests.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
@@ -822,6 +832,7 @@ sun/security/pkcs12/StorePasswordTest.java https://github.com/eclipse-openj9/ope
 sun/security/pkcs12/StoreSecretKeyTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/StoreTrustedCertTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/WrongPBES2.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/DSA/SecureRandomReset.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/DSA/SupportedDSAParamGen.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/DSA/SupportedDSAParamGenLongKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1028,7 +1039,7 @@ sun/security/ssl/rsa/CheckProviderEntries.java https://github.com/eclipse-openj9
 sun/security/ssl/rsa/SignatureOffsets.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/rsa/SignedObjectChain.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/spi/ProviderInit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/tools/jarsigner/CertChainUnclosed.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
+sun/security/tools/jarsigner/CertChainUnclosed.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/DefaultSigalg.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/EntriesOrder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/JarSigningNonAscii.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1084,6 +1095,9 @@ sun/security/x509/AlgorithmId/NonStandardNames.java https://github.com/eclipse-o
 sun/security/x509/AlgorithmId/OmitAlgIdParam.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/AlgorithmId/PBES2.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/AlgorithmId/Uppercase.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/x509/CertificateValidity/NullName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/x509/EDIPartyName/NullName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/x509/Extensions/IllegalExtensions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/OtherName/Parse.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/URICertStore/AIACertTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/URICertStore/CRLReadTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -162,7 +162,7 @@ java/lang/Class/GetPackageBootLoaderChildLayer.java https://github.com/ibmruntim
 java/lang/ClassLoader/forNameLeak/ClassForNameLeak.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/lang/ProcessBuilder/JspawnhelperWarnings.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/lang/SecurityManager/CheckSecurityProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-java/lang/String/CompactString/NegativeSize.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 aix-all,linux-ppc64le,linux-s390x,windows-all
+java/lang/String/CompactString/NegativeSize.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/lang/reflect/records/IsRecordTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/lang/reflect/records/RecordPermissionsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/lang/reflect/records/RecordReflectionTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -292,7 +292,7 @@ javax/crypto/Cipher/TestCipherMode.java https://github.com/ibmruntimes/openj9-op
 javax/crypto/Cipher/TestGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/crypto/Cipher/Turkish.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/crypto/CipherSpi/DirectBBRemaining.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-javax/crypto/CipherSpi/ResetByteBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-s390x,windows-all
+javax/crypto/CipherSpi/ResetByteBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/crypto/CryptoPermission/AllPermCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/crypto/CryptoPermission/LowercasePermCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/crypto/CryptoPermission/RC2PermCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -354,7 +354,7 @@ sun/security/krb5/auto/BasicKrb5Test.java https://github.com/ibmruntimes/openj9-
 sun/security/krb5/auto/BasicProc.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/krb5/auto/BogusKDC.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/krb5/auto/CleanState.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/krb5/auto/Cleaners.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-ppc64le,linux-s390x,linux-x64,windows-all
+sun/security/krb5/auto/Cleaners.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/krb5/auto/CrossRealm.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/krb5/auto/DiffNameSameKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/krb5/auto/DiffSaltParams.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -431,6 +431,7 @@ sun/security/krb5/ktab/BufferBoundary.java https://github.com/ibmruntimes/openj9
 sun/security/krb5/ktab/FileKeyTab.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/krb5/ktab/KeyTabIndex.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/krb5/runNameEquals.sh https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/provider/all/Deterministic.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 #
 # Exclude tests list from extended.openjdk
 #
@@ -470,10 +471,10 @@ java/io/Serializable/records/WriteReplaceTest.java https://github.com/ibmruntime
 java/io/Serializable/serialFilter/FilterWithSecurityManagerTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/io/Serializable/serialFilter/GlobalFilterTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/io/Serializable/serialFilter/SerialFilterFactoryTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-x64,windows-all
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/nio/channels/Selector/SelectWithConsumer.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-java/nio/channels/etc/OpenAndConnect.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-x64,windows-all
-java/nio/channels/etc/ProtocolFamilies.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-x64,windows-all
+java/nio/channels/etc/OpenAndConnect.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+java/nio/channels/etc/ProtocolFamilies.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/nio/channels/unixdomain/IOExchanges.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/nio/channels/unixdomain/Security.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 java/nio/file/Files/CopyToNonDefaultFS.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -623,7 +624,7 @@ javax/net/ssl/TLSv11/ExportableStreamCipher.java https://github.com/ibmruntimes/
 javax/net/ssl/TLSv11/GenericBlockCipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/net/ssl/TLSv11/GenericStreamCipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/net/ssl/TLSv11/TLSDataExchangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-javax/net/ssl/TLSv11/TLSEnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-ppc64le,linux-s390x,linux-x64,windows-all
+javax/net/ssl/TLSv11/TLSEnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/net/ssl/TLSv11/TLSHandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/net/ssl/TLSv11/TLSMFLNTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 javax/net/ssl/TLSv11/TLSNotEnabledRC4Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -672,7 +673,7 @@ jdk/nio/zipfs/PropertyPermissionTests.java https://github.com/ibmruntimes/openj9
 jdk/nio/zipfs/TestPosix.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 jdk/nio/zipfs/ZFSTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 jdk/nio/zipfs/ZipFSPermissionsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-jdk/nio/zipfs/ZipFSTester.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 aix-all,linux-ppc64le,linux-s390x,windows-all
+jdk/nio/zipfs/ZipFSTester.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 jdk/security/jarsigner/Function.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 jdk/security/jarsigner/JarWithOneNonDisabledDigestAlg.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 jdk/security/jarsigner/Properties.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -691,7 +692,7 @@ sun/security/ec/SignatureDigestTruncate.java https://github.com/ibmruntimes/open
 sun/security/ec/SignatureKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ec/SignatureParameters.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ec/SignedObjectChain.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/ec/TestEC.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-ppc64le,linux-s390x,linux-x64,windows-all
+sun/security/ec/TestEC.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ec/ed/EdCRLSign.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ec/ed/EdDSAKeyCompatibility.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ec/ed/EdDSAKeySize.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -707,17 +708,17 @@ sun/security/ec/xec/TestXDH.java https://github.com/ibmruntimes/openj9-openjdk-j
 sun/security/ec/xec/XECKeyFormat.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/jca/PreferredProviderNegativeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/jca/PreferredProviderTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/mscapi/AccessKeyStore.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/AllTypes.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/DupAlias.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/EncodingMutability.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/IsSunMSCAPIAvailable.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/IterateWindowsRootStore.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/KeyStoreCompatibilityMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/KeytoolChangeAlias.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/NullKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/PrngSerialize.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
-sun/security/mscapi/PrngSlow.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 windows-all
+sun/security/mscapi/AccessKeyStore.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/AllTypes.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/DupAlias.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/EncodingMutability.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/IsSunMSCAPIAvailable.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/IterateWindowsRootStore.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/KeyStoreCompatibilityMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/KeytoolChangeAlias.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/NullKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/PrngSerialize.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
+sun/security/mscapi/PrngSlow.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs/pkcs10/PKCS10AttrEncoding.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs/pkcs7/PKCS7VerifyTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs/pkcs7/SignerOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -726,7 +727,7 @@ sun/security/pkcs/pkcs8/TestLeadingZeros.java https://github.com/ibmruntimes/ope
 sun/security/pkcs11/KeyStore/ClientAuth.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs11/Provider/Absolute.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs11/SecretKeyFactory/TestPBKD.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 aix-all,linux-s390x,linux-x64,windows-all
+sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs12/Bug6415637.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs12/EmptyPassword.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/pkcs12/GetAttributes.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -816,12 +817,12 @@ sun/security/ssl/AppInputStream/ReadZeroBytes.java https://github.com/ibmruntime
 sun/security/ssl/AppInputStream/RemoveMarkReset.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/AppOutputStream/NoExceptionOnClose.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/CertPathRestrictions/TLSRestrictions.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/ssl/CipherSuite/DisabledCurve.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-ppc64le,linux-s390x,linux-x64,windows-all
+sun/security/ssl/CipherSuite/DisabledCurve.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/CipherSuite/LegacyConstraints.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-ppc64le,linux-s390x,linux-x64,windows-all
+sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/CipherSuite/RestrictNamedGroup.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/CipherSuite/RestrictSignatureScheme.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/ssl/CipherSuite/SupportedGroups.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-ppc64le,linux-s390x,linux-x64,windows-all
+sun/security/ssl/CipherSuite/SupportedGroups.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/ClientHandshaker/CipherSuiteOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/ClientHandshaker/LengthCheckTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/ssl/ClientHandshaker/RSAExport.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
@@ -935,7 +936,7 @@ sun/security/tools/jarsigner/EntriesOrder.java https://github.com/ibmruntimes/op
 sun/security/tools/jarsigner/JarSigningNonAscii.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/tools/jarsigner/LargeJarEntry.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/tools/jarsigner/LineBrokenMultiByteCharacter.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
-sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 linux-ppc64le,linux-s390x,linux-x64,windows-all
+sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/tools/jarsigner/Test4431684.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/tools/jarsigner/TimestampCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all
 sun/security/tools/jarsigner/TsacertOptionTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/820 generic-all


### PR DESCRIPTION
This update migrates all FIPS excluded tests to be platform agnostic.

Some tests are referencing an incorrect issue number unrelated to the test.

Additional tests failing have been added to the excludes list since they are not expected to be running anytime soon.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/915

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>