### PR TITLE
Remove support for EC aliases in SunPKCS11

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -868,7 +868,7 @@ public final class SunPKCS11 extends AuthProvider {
         d(KPG, "DH",            P11KeyPairGenerator,
                 dhAlias,
                 m(CKM_DH_PKCS_KEY_PAIR_GEN));
-        dA(KPG, "EC",            P11KeyPairGenerator,
+        d(KPG, "EC",            P11KeyPairGenerator,
                 m(CKM_EC_KEY_PAIR_GEN));
 
         dA(KG,  "ARCFOUR",       P11KeyGenerator,
@@ -918,7 +918,7 @@ public final class SunPKCS11 extends AuthProvider {
         d(KF, "DH",             P11DHKeyFactory,
                 dhAlias,
                 m(CKM_DH_PKCS_KEY_PAIR_GEN, CKM_DH_PKCS_DERIVE));
-        dA(KF, "EC",             P11ECKeyFactory,
+        d(KF, "EC",             P11ECKeyFactory,
                 m(CKM_EC_KEY_PAIR_GEN, CKM_ECDH1_DERIVE,
                     CKM_ECDSA, CKM_ECDSA_SHA1));
 


### PR DESCRIPTION
Reverting a previous commit (8ddd8d766221c1ac26455512698bcf58d6e24a1c) that added support for EC aliases in KeyFactory and KeyPairGenerator for SunPKCS11.

This was previously supported in Java 8 on Z by the IBMPKCS11Impl provider. However, an openjdk contributer noted that OID is not commonly used for the KeyFactory and KeyGenerator services. Instead, the standard "EC" string should be used as an input to generate EC keys.

Given the upstream stance, no requests for continuing this support, and the availability of an alternative, this change should be removed.