### PR TITLE
Update getState() API to use holder.threadStatus field

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -2433,20 +2433,58 @@ public class Thread implements Runnable {
     }
 
     /**
+     * Returns the translation from a J9VMThread state to a Thread::State.
+     *
+     * @return this thread's state.
+     *
+     * @see State
+     */
+    private State translateJ9VMThreadStateToThreadState(int status) {
+        switch (status) {
+            case 1: // J9VMTHREAD_STATE_RUNNING
+                return State.RUNNABLE;
+            case 2: // J9VMTHREAD_STATE_BLOCKED
+                return State.BLOCKED;
+            case 4: // J9VMTHREAD_STATE_WAITING
+            case 0x80: // J9VMTHREAD_STATE_PARKED
+                return State.WAITING;
+            case 8: // J9VMTHREAD_STATE_SLEEPING
+            case 64: // J9VMTHREAD_STATE_WAITING_TIMED
+            case 0x100: // J9VMTHREAD_STATE_PARKED_TIMED
+                return State.TIMED_WAITING;
+            case 32: // J9VMTHREAD_STATE_DEAD
+                return State.TERMINATED;
+            default:
+                synchronized (interruptLock) {
+                    if (eetop == NO_REF) {
+                        return State.TERMINATED;
+                    }
+                    return State.values()[getStateImpl(eetop)];
+                }
+        }
+    }
+
+    /**
      * Returns the state of this thread.
      * This method can be used instead of getState as getState is not final and
      * so can be overridden to run arbitrary code.
      */
     State threadState() {
-        synchronized (interruptLock) {
+        if (started) {
             if (eetop == NO_REF) {
-                if (isDead()) {
-                    return State.TERMINATED;
-                }
-                return State.NEW;
+                return State.TERMINATED;
             }
-            return State.values()[getStateImpl(eetop)];
+            if (holder == null) {
+                synchronized (interruptLock) {
+                    if (eetop == NO_REF) {
+                        return State.TERMINATED;
+                    }
+                    return State.values()[getStateImpl(eetop)];
+                }
+            }
+            return translateJ9VMThreadStateToThreadState(holder.threadStatus);
         }
+        return State.NEW;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -2435,32 +2435,33 @@ public class Thread implements Runnable {
     /**
      * Returns the translation from a J9VMThread state to a Thread::State.
      *
+     * @param status thread status value set by VM.
      * @return this thread's state.
      *
      * @see State
      */
     private State translateJ9VMThreadStateToThreadState(int status) {
         switch (status) {
-            case 1: // J9VMTHREAD_STATE_RUNNING
-                return State.RUNNABLE;
-            case 2: // J9VMTHREAD_STATE_BLOCKED
-                return State.BLOCKED;
-            case 4: // J9VMTHREAD_STATE_WAITING
-            case 0x80: // J9VMTHREAD_STATE_PARKED
-                return State.WAITING;
-            case 8: // J9VMTHREAD_STATE_SLEEPING
-            case 64: // J9VMTHREAD_STATE_WAITING_TIMED
-            case 0x100: // J9VMTHREAD_STATE_PARKED_TIMED
-                return State.TIMED_WAITING;
-            case 32: // J9VMTHREAD_STATE_DEAD
-                return State.TERMINATED;
-            default:
-                synchronized (interruptLock) {
-                    if (eetop == NO_REF) {
-                        return State.TERMINATED;
-                    }
-                    return State.values()[getStateImpl(eetop)];
+        case 1: // J9VMTHREAD_STATE_RUNNING
+            return State.RUNNABLE;
+        case 2: // J9VMTHREAD_STATE_BLOCKED
+            return State.BLOCKED;
+        case 4: // J9VMTHREAD_STATE_WAITING
+        case 0x80: // J9VMTHREAD_STATE_PARKED
+            return State.WAITING;
+        case 8: // J9VMTHREAD_STATE_SLEEPING
+        case 64: // J9VMTHREAD_STATE_WAITING_TIMED
+        case 0x100: // J9VMTHREAD_STATE_PARKED_TIMED
+            return State.TIMED_WAITING;
+        case 32: // J9VMTHREAD_STATE_DEAD
+            return State.TERMINATED;
+        default:
+            synchronized (interruptLock) {
+                if (eetop == NO_REF) {
+                    return State.TERMINATED;
                 }
+                return State.values()[getStateImpl(eetop)];
+            }
         }
     }
 
@@ -2475,12 +2476,10 @@ public class Thread implements Runnable {
                 return State.TERMINATED;
             }
             if (holder == null) {
-                synchronized (interruptLock) {
-                    if (eetop == NO_REF) {
-                        return State.TERMINATED;
-                    }
-                    return State.values()[getStateImpl(eetop)];
+                if (eetop == NO_REF) {
+                    return State.TERMINATED;
                 }
+                return State.values()[getStateImpl(eetop)];
             }
             return translateJ9VMThreadStateToThreadState(holder.threadStatus);
         }


### PR DESCRIPTION
depend: https://github.com/eclipse-openj9/openj9/pull/21043
Rework of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/879