### PR TITLE
Allow use of conditional code in DDR tools

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,8 +24,8 @@
 #     * compile tools
 #     * generate java pointer source files
 #     * generate java structure stub source files
-#     * generate pointer and structure stub class files
 # - compile_check
+#     * generate pointer and structure stub class files
 #     * compile DDR_VM source with the generated class files from above
 # ===========================================================================
 
@@ -41,8 +41,9 @@ include $(SPEC)
 include $(TOPDIR)/make/common/MakeBase.gmk
 include $(TOPDIR)/make/common/JavaCompilation.gmk
 
-# The main source directory.
-DDR_VM_SRC_ROOT := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
+# The main source directories.
+DDR_VM_SRC_ROOT_BOOT := $(J9JCL_SOURCES_DIR)/ddr/interim
+DDR_VM_SRC_ROOT_NEW  := $(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes
 
 # The top-level directory for intermediate artifacts.
 DDR_SUPPORT_DIR := $(SUPPORT_OUTPUTDIR)/ddr
@@ -54,7 +55,8 @@ DDR_SUPERSET_FILE := $(OUTPUTDIR)/vm/superset.dat
 # Where to write class files.
 DDR_CLASSES_BIN := $(DDR_SUPPORT_DIR)/classes
 DDR_TEST_BIN := $(DDR_SUPPORT_DIR)/test
-DDR_TOOLS_BIN := $(DDR_SUPPORT_DIR)/tools
+DDR_TOOLS_BIN_BOOT := $(DDR_SUPPORT_DIR)/tools-interim
+DDR_TOOLS_BIN_NEW := $(DDR_SUPPORT_DIR)/tools
 
 # Where to write generated source files.
 DDR_GENSRC_DIR := $(SUPPORT_OUTPUTDIR)/gensrc/openj9.dtfj
@@ -64,34 +66,48 @@ DDR_CLASSES_MARKER := $(DDR_SUPPORT_DIR)/classes.done
 DDR_POINTERS_MARKER := $(DDR_SUPPORT_DIR)/gensrc-pointers.done
 DDR_STRUCTURES_MARKER := $(DDR_SUPPORT_DIR)/gensrc-structures.done
 
+# The list of source files that must be compiled
+# (for either the source or class generation steps).
+DDR_TOOLS_SOURCE_FILES := \
+	com/ibm/j9ddr/BytecodeGenerator.java \
+	com/ibm/j9ddr/CTypeParser.java \
+	com/ibm/j9ddr/StructureHeader.java \
+	com/ibm/j9ddr/StructureReader.java \
+	com/ibm/j9ddr/StructureTypeManager.java \
+	com/ibm/j9ddr/logging/LoggerNames.java \
+	com/ibm/j9ddr/tools/ClassGenerator.java \
+	com/ibm/j9ddr/tools/FlagStructureList.java \
+	com/ibm/j9ddr/tools/PointerGenerator.java \
+	com/ibm/j9ddr/tools/StructureStubGenerator.java \
+	com/ibm/j9ddr/tools/store/J9DDRStructureStore.java \
+	com/ibm/j9ddr/tools/store/StructureKey.java \
+	com/ibm/j9ddr/tools/store/StructureMismatchError.java \
+	#
+
 #############################################################################
 
-# Build the tools we will need.
-$(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS, \
+# Build the tools for use with the boot JDK.
+$(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS_BOOT, \
 	TARGET_RELEASE := $(TARGET_RELEASE_BOOTJDK), \
-	BIN := $(DDR_TOOLS_BIN), \
+	BIN := $(DDR_TOOLS_BIN_BOOT), \
 	CLASSPATH := $(JDK_OUTPUTDIR)/modules/java.base, \
 	JAVAC_FLAGS := --add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED, \
-	SRC := $(DDR_VM_SRC_ROOT), \
-	INCLUDE_FILES := \
-		com/ibm/j9ddr/BytecodeGenerator.java \
-		com/ibm/j9ddr/CTypeParser.java \
-		com/ibm/j9ddr/StructureHeader.java \
-		com/ibm/j9ddr/StructureReader.java \
-		com/ibm/j9ddr/StructureTypeManager.java \
-		com/ibm/j9ddr/logging/LoggerNames.java \
-		com/ibm/j9ddr/tools/ClassGenerator.java \
-		com/ibm/j9ddr/tools/FlagStructureList.java \
-		com/ibm/j9ddr/tools/PointerGenerator.java \
-		com/ibm/j9ddr/tools/StructureStubGenerator.java \
-		com/ibm/j9ddr/tools/store/J9DDRStructureStore.java \
-		com/ibm/j9ddr/tools/store/StructureKey.java \
-		com/ibm/j9ddr/tools/store/StructureMismatchError.java \
+	SRC := $(DDR_SUPPORT_DIR)/interim, \
+	INCLUDE_FILES := $(DDR_TOOLS_SOURCE_FILES), \
+	))
+
+# Build the tools for use with the new JDK.
+$(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS_NEW, \
+	TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
+	BIN := $(DDR_TOOLS_BIN_NEW), \
+	CLASSPATH := $(JDK_OUTPUTDIR)/modules/java.base, \
+	SRC := $(DDR_VM_SRC_ROOT_NEW), \
+	INCLUDE_FILES := $(DDR_TOOLS_SOURCE_FILES), \
 	))
 
 # Any new references to constants must be paired with additions to the compatibility
 # list unless those constants were defined long ago.
-DDR_COMPATIBILITY_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/CompatibilityConstants29.dat
+DDR_COMPATIBILITY_FILE := $(DDR_VM_SRC_ROOT_NEW)/com/ibm/j9ddr/CompatibilityConstants29.dat
 
 #############################################################################
 
@@ -101,28 +117,33 @@ DDR_COMPATIBILITY_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/CompatibilityConstant
 # might be included: Patching openj9.dtfj fixes that. We use FixPath because
 # fixpath.sh would only fix the first entry of the path.
 DDR_PATH_SEP := $(if $(filter $(OPENJDK_BUILD_OS),windows),;,:)
-DDR_TOOLS_PATHLIST := "$(call FixPath,$(DDR_TOOLS_BIN))$(DDR_PATH_SEP)$(call FixPath,$(DDR_VM_SRC_ROOT))"
-DDR_TOOLS_OPTIONS := \
-	-cp $(DDR_TOOLS_PATHLIST) \
-	--patch-module=openj9.dtfj=$(DDR_TOOLS_PATHLIST)
+
+DDR_TOOLS_PATHLIST_BOOT := "$(call FixPath,$(DDR_TOOLS_BIN_BOOT))$(DDR_PATH_SEP)$(call FixPath,$(DDR_VM_SRC_ROOT_BOOT))"
+DDR_TOOLS_OPTIONS_BOOT := \
+	-cp $(DDR_TOOLS_PATHLIST_BOOT) \
+	--patch-module=openj9.dtfj=$(DDR_TOOLS_PATHLIST_BOOT)
+
+DDR_TOOLS_PATHLIST_NEW := "$(call FixPath,$(DDR_TOOLS_BIN_NEW))$(DDR_PATH_SEP)$(call FixPath,$(DDR_VM_SRC_ROOT_NEW))"
+DDR_TOOLS_OPTIONS_NEW := \
+	-cp $(DDR_TOOLS_PATHLIST_NEW) \
+	--patch-module=openj9.dtfj=$(DDR_TOOLS_PATHLIST_NEW)
 
 # Only fields listed in this file can be directly accessed by hand-written DDR code;
 # its contents influence the generated class files.
-DDR_FIELDS_FILE := $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/AuxFieldInfo29.dat
+DDR_FIELDS_FILE := $(DDR_VM_SRC_ROOT_NEW)/com/ibm/j9ddr/AuxFieldInfo29.dat
 
-$(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(DDR_COMPATIBILITY_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)
+$(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(DDR_COMPATIBILITY_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS_NEW)
 	@$(ECHO) Generating DDR pointer and structure class files
 	@$(RM) -rf $(DDR_CLASSES_BIN)
-	@$(JAVA) $(DDR_TOOLS_OPTIONS) \
-		--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED \
+	@$(JDK_OUTPUTDIR)/bin/java $(DDR_TOOLS_OPTIONS_NEW) \
 		com.ibm.j9ddr.tools.ClassGenerator \
 			--blob=$(DDR_BLOB_FILE) \
 			--out=$(DDR_CLASSES_BIN)
 	@$(TOUCH) $@
 
-$(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)
+$(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS_BOOT)
 	@$(ECHO) Generating DDR pointer class source files
-	@$(JAVA) $(DDR_TOOLS_OPTIONS) com.ibm.j9ddr.tools.PointerGenerator \
+	@$(JAVA) $(DDR_TOOLS_OPTIONS_BOOT) com.ibm.j9ddr.tools.PointerGenerator \
 		-a $(DDR_FIELDS_FILE) \
 		-f $(dir $(DDR_SUPERSET_FILE)) \
 		-s $(notdir $(DDR_SUPERSET_FILE)) \
@@ -133,9 +154,9 @@ $(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOO
 
 DDR_RESTRICT_FILE := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/data/superset-constants.dat
 
-$(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_RESTRICT_FILE) $(DDR_COMPATIBILITY_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS)
+$(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_RESTRICT_FILE) $(DDR_COMPATIBILITY_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS_BOOT)
 	@$(ECHO) Generating DDR structure stub source files
-	@$(JAVA) $(DDR_TOOLS_OPTIONS) com.ibm.j9ddr.tools.StructureStubGenerator \
+	@$(JAVA) $(DDR_TOOLS_OPTIONS_BOOT) com.ibm.j9ddr.tools.StructureStubGenerator \
 		-f $(dir $(DDR_SUPERSET_FILE)) \
 		-s $(notdir $(DDR_SUPERSET_FILE)) \
 		-p com.ibm.j9ddr.vm29.structure \
@@ -150,9 +171,9 @@ $(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_RESTRICT_FILE) $(DDR_COMPA
 # or StructureStubGenerator) has already done so:
 #   /usr/bin/cp: cannot create directory 'support/gensrc/openj9.dtfj/com/ibm/j9ddr/vm29': File exists
 # To avoid that problem, we insist that $(CP) runs before the other tasks.
-$(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER) : $(call FindFiles,$(DDR_VM_SRC_ROOT))
+$(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER) : $(call FindFiles, $(DDR_VM_SRC_ROOT_NEW))
 
-generate : $(DDR_CLASSES_MARKER) $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)
+generate : $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)
 
 #############################################################################
 
@@ -171,7 +192,7 @@ $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
 		--system none, \
 	BIN := $(DDR_TEST_BIN), \
 	CLASSPATH := $(DDR_CLASSES_BIN), \
-	SRC := $(J9JCL_SOURCES_DIR)/openj9.dtfj/share/classes \
+	SRC := $(DDR_VM_SRC_ROOT_NEW) \
 	))
 
 .PHONY : compile_check

--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -72,6 +72,11 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 
 IncludeIfUnsure := -includeIfUnsure -noWarnIncludeIf
 
+# OLDEST_BOOT_JDK is not available directly, but it can be extracted
+# from BOOT_JDK_SOURCETARGET which has a value like:
+#     -source $OLDEST_BOOT_JDK -target $OLDEST_BOOT_JDK -Xlint:-options
+BOOT_JDK_VERSION := $(word 2, $(BOOT_JDK_SOURCETARGET))
+
 $(J9JCL_SOURCES_DONEFILE) : \
 		$(foreach dir, $(JppSourceDirs), $(call RecursiveWildcard,$(dir),*)) \
 		$(COPY_OVERLAY_FILES)
@@ -88,7 +93,12 @@ $(J9JCL_SOURCES_DONEFILE) : \
 	$(call RunJPP, JAVA$(VERSION_FEATURE), $(OPENJ9_TOPDIR)/jcl, /j9jcl)
   ifeq (true,$(OPENJ9_ENABLE_DDR))
 	@$(ECHO) Generating DDR_VM sources
-	$(call RunJPP, GENERIC, $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, /j9jcl/openj9.dtfj/share/classes, $(IncludeIfUnsure) -macro:define JAVA_SPEC_VERSION=$(VERSION_FEATURE))
+	$(call RunJPP, GENERIC, $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, /j9jcl/openj9.dtfj/share/classes, \
+		$(IncludeIfUnsure) -macro:define JAVA_SPEC_VERSION=$(VERSION_FEATURE))
+    # Also generate source that can be used with the boot JDK.
+	@$(ECHO) Generating DDR_VM interim sources
+	$(call RunJPP, GENERIC, $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, /ddr/interim, \
+		$(IncludeIfUnsure) -macro:define JAVA_SPEC_VERSION=$(BOOT_JDK_VERSION))
   endif # OPENJ9_ENABLE_DDR
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -91,7 +91,7 @@ ifeq (true,$(OPENJ9_ENABLE_DDR))
 
 openj9.dtfj-gensrc-src : j9vm-build
 
-openj9.dtfj-compile_check : openj9.dtfj-java
+openj9.dtfj-compile_check : exploded-image
 	+$(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/DDR.gmk compile_check
 
 openj9.dtfj-jmod : openj9.dtfj-compile_check


### PR DESCRIPTION
Create a second copy suitable for use with the boot JDK.

Delay DDR compile_check to use the exploded JDK.

This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/933.