### PR TITLE
Update makefiles for Windows

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -114,16 +114,16 @@ DDR_COMPATIBILITY_FILE := $(DDR_VM_SRC_ROOT_NEW)/com/ibm/j9ddr/CompatibilityCons
 # When StructureReader opens the blob, it must be able to find AuxFieldInfo29.dat
 # and StructureAliases*.dat, so they must be on the classpath for a non-openj9
 # bootjdk. When using an openj9 bootjdk, we don't want to use old versions that
-# might be included: Patching openj9.dtfj fixes that. We use FixPath because
+# might be included: Patching openj9.dtfj fixes that. We use MixedPath because
 # fixpath.sh would only fix the first entry of the path.
 DDR_PATH_SEP := $(if $(filter $(OPENJDK_BUILD_OS),windows),;,:)
 
-DDR_TOOLS_PATHLIST_BOOT := "$(call FixPath,$(DDR_TOOLS_BIN_BOOT))$(DDR_PATH_SEP)$(call FixPath,$(DDR_VM_SRC_ROOT_BOOT))"
+DDR_TOOLS_PATHLIST_BOOT := "$(call MixedPath,$(DDR_TOOLS_BIN_BOOT))$(DDR_PATH_SEP)$(call MixedPath,$(DDR_VM_SRC_ROOT_BOOT))"
 DDR_TOOLS_OPTIONS_BOOT := \
 	-cp $(DDR_TOOLS_PATHLIST_BOOT) \
 	--patch-module=openj9.dtfj=$(DDR_TOOLS_PATHLIST_BOOT)
 
-DDR_TOOLS_PATHLIST_NEW := "$(call FixPath,$(DDR_TOOLS_BIN_NEW))$(DDR_PATH_SEP)$(call FixPath,$(DDR_VM_SRC_ROOT_NEW))"
+DDR_TOOLS_PATHLIST_NEW := "$(call MixedPath,$(DDR_TOOLS_BIN_NEW))$(DDR_PATH_SEP)$(call MixedPath,$(DDR_VM_SRC_ROOT_NEW))"
 DDR_TOOLS_OPTIONS_NEW := \
 	-cp $(DDR_TOOLS_PATHLIST_NEW) \
 	--patch-module=openj9.dtfj=$(DDR_TOOLS_PATHLIST_NEW)
@@ -137,8 +137,8 @@ $(DDR_CLASSES_MARKER) : $(DDR_BLOB_FILE) $(DDR_COMPATIBILITY_FILE) $(DDR_FIELDS_
 	@$(RM) -rf $(DDR_CLASSES_BIN)
 	@$(JDK_OUTPUTDIR)/bin/java $(DDR_TOOLS_OPTIONS_NEW) \
 		com.ibm.j9ddr.tools.ClassGenerator \
-			--blob=$(DDR_BLOB_FILE) \
-			--out=$(DDR_CLASSES_BIN)
+			--blob=$(call MixedPath,$(DDR_BLOB_FILE)) \
+			--out=$(call MixedPath,$(DDR_CLASSES_BIN))
 	@$(TOUCH) $@
 
 $(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(DDR_FIELDS_FILE) $(BUILD_DDR_TOOLS_BOOT)

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -97,8 +97,8 @@ ifeq ($(call isTargetOs, windows), true)
   # convert windows path to unix path
   UnixPath = $(shell $(PATHTOOL) -u $1)
   # set up Visual Studio environment
-  # - wrap LIB in single-quotes to hide backslashes from make
-  EXPORT_COMPILER_ENV_VARS := LIB='$(OPENJ9_VS_LIB)'
+  # - single-quotes hide backslashes from make
+  EXPORT_COMPILER_ENV_VARS := INCLUDE='$(OPENJ9_VS_INCLUDE)' LIB='$(OPENJ9_VS_LIB)'
 else ifeq ($(call isTargetOs, zos), true)
   UnixPath = $1
   # allow options to follow the input file name

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -104,9 +104,9 @@ export ac_cv_prog_CC    := @CC@
 export ac_cv_prog_CXX   := @CXX@
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
-  # Set environment variables for Microsoft Visual Studio toolchain.
+  # Set variables for the Microsoft Visual Studio toolchain.
   # Note that PATH is set in spec.gmk.
-  export INCLUDE := @OPENJ9_VS_INCLUDE@
+  OPENJ9_VS_INCLUDE := @OPENJ9_VS_INCLUDE@
   OPENJ9_VS_LIB := @OPENJ9_VS_LIB@
   export MSVC_VERSION := @TOOLCHAIN_VERSION@
 endif

--- a/closed/make/modules/openjceplus/Lib.gmk
+++ b/closed/make/modules/openjceplus/Lib.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -52,8 +52,8 @@ else ifeq ($(call isTargetOs, macosx), true)
   endif
   OPENJCEPLUS_JGSKIT_MAKE := jgskit.mac.mak
 else ifeq ($(call isTargetOs, windows), true)
+  EXPORT_COMPILER_ENV_VARS := INCLUDE='$(OPENJ9_VS_INCLUDE)' LIB='$(OPENJ9_VS_LIB)'
   ifeq ($(call isTargetCpu, x86_64), true)
-    EXPORT_COMPILER_ENV_VARS := LIB='$(OPENJ9_VS_LIB)'
     OPENJCEPLUS_JDK := $(call MixedPath,$(OPENJCEPLUS_JDK))
     OPENJCEPLUS_GSKIT_HOME := $(call MixedPath,$(OPENJCEPLUS_GSKIT_HOME))
     OPENJCEPLUS_HEADER_FILES := $(call MixedPath,$(OPENJCEPLUS_HEADER_FILES))

--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -37,9 +37,8 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
   # Configure produces a makefile intended for use with nmake.
   OPENSSL_MAKE := nmake
 
-  # LIB cannot have the surrounding double-quotes provided by custom-spec.gmk.
   # MAKEFLAGS uses unix-style options (with a dash) which won't be understood by nmake.
-  OPENSSL_MAKE_SETUP := export LIB='$(OPENJ9_VS_LIB)' && unset MAKEFLAGS &&
+  OPENSSL_MAKE_SETUP := export INCLUDE='$(OPENJ9_VS_INCLUDE)' LIB='$(OPENJ9_VS_LIB)' && unset MAKEFLAGS &&
 
   # The makefile produced by OpenSSL 3+ during the configure step needs to be
   # patched. Patching involves adding double-quotes around the name of perl


### PR DESCRIPTION
Export `INCLUDE` only where it is needed.

Use `MixedPath` in `DDR.gmk` to get usable paths on Windows.

This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/943.