### PR TITLE
Add openj9.cuda and openj9.dtfj to NATIVE_ACCESS_MODULES

### DIFF
--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -55,6 +55,11 @@ MODULES_FILTER += \
 	jdk.internal.vm.compiler \
 	jdk.internal.vm.compiler.management \
 	jdk.jstatd \
+	#
+
+NATIVE_ACCESS_MODULES += \
+	openj9.cuda \
+	openj9.dtfj \
 	#
 
 TOP_SRC_DIRS += \


### PR DESCRIPTION
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/953.