### PR TITLE
Add openjceplus module to NATIVE_ACCESS_MODULES

### DIFF
--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -60,6 +60,7 @@ MODULES_FILTER += \
 NATIVE_ACCESS_MODULES += \
 	openj9.cuda \
 	openj9.dtfj \
+	$(if $(call equals, $(BUILD_OPENJCEPLUS), true), openjceplus) \
 	#
 
 TOP_SRC_DIRS += \


### PR DESCRIPTION
The openjceplus module makes use of native code which results in a warning message being printed on Java 24 and higher. This update adds the openjceplus module to the NATIVE_ACCESS_MODULES which suppresses this warning message.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/955

Signed-off-by: Jason Katonica <katonica@us.ibm.com>