### PR TITLE
Fix selectedProfile overridden by a null property semeru.customprofile

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -138,9 +138,14 @@ public final class RestrictedSecurity {
             }
         }
 
-        // If user has specified a profile, use that
-        selectedProfile = System.getProperty("semeru.customprofile");
-        userSetProfile = selectedProfile != null;
+        // If user has specified a profile, use that.
+        String semeruCustomProfile = System.getProperty("semeru.customprofile");
+        if (semeruCustomProfile != null) {
+            selectedProfile = semeruCustomProfile;
+            userSetProfile = true;
+        } else {
+            userSetProfile = false;
+        }
 
         // Check if FIPS is supported on this platform without explicitly setting a profile.
         if (userEnabledFIPS && !isFIPSSupported && !userSetProfile) {


### PR DESCRIPTION
Fix `selectedProfile` overridden by a `null` property `semeru.customprofile`

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/956

Signed-off-by: Jason Feng <fengj@ca.ibm.com>