### PR TITLE
Integrate fix for 8352302

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
+++ b/test/jdk/sun/security/tools/jarsigner/TimestampCheck.java
@@ -905,7 +905,7 @@ public class TimestampCheck {
         }
 
         gencert("tsold", "-ext eku:critical=ts -startdate -40d -validity 500");
-        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 3000");
+        gencert("tsbefore2019", "-ext eku:critical=ts -startdate 2018/01/01 -validity 5000");
 
         gencert("tsweak", "-ext eku:critical=ts");
         gencert("tsdisabled", "-ext eku:critical=ts");


### PR DESCRIPTION
8352302: Test sun/security/tools/jarsigner/TimestampCheck.java is failing
https://github.com/openjdk/jdk24u/commit/9880a973ea1538eb9bee061cdf53ea75397364e9

Issue https://github.com/eclipse-openj9/openj9/issues/21436

The head stream will get this naturally via https://github.com/openjdk/jdk/commit/577ede73d8e916bac9050d3bee80d2f18cc833a7.
jdk24 should also get it naturally, likely for 24.0.1, but bring it in now to avoid the failure.