### PR TITLE
Add ProblemList-OpenJCEPlus.txt as placeholder for JDK24

### DIFF
--- a/test/jdk/ProblemList-OpenJCEPlus.txt
+++ b/test/jdk/ProblemList-OpenJCEPlus.txt
@@ -1,0 +1,19 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================


### PR DESCRIPTION
Add ProblemList-OpenJCEPlus.txt as placeholder

related: https://github.com/adoptium/aqa-tests/pull/6129, https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/977#issuecomment-2770313607 and automation/issues/78