### PR TITLE
Check RestrictedSecurity profile hash after Providers init

### DIFF
--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -111,6 +111,7 @@ public class Providers {
         // triggers a getInstance() call (although that should not happen)
         providerList = ProviderList.EMPTY;
         providerList = ProviderList.fromSecurityProperties();
+        RestrictedSecurity.checkHashValues();
     }
 
     // Return Sun provider.


### PR DESCRIPTION
If the `Providers` class hasn't had a chance to initialize, the required message digest algorithms are not available to check the hash value of the `RestrictedSecurity` profile.

With this change, the check is only allowed after the appropriate initialization has been performed.

Issue https://github.com/eclipse-openj9/openj9/issues/21615

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/991

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>