### PR TITLE
GetThreadStateTest.testObjectWait check to await

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java
@@ -190,7 +190,7 @@ class GetThreadStateTest {
             synchronized (lock) {
                 lock.notifyAll();
                 expected = JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER;
-                check(thread, expected);
+                await(thread, expected);
 
                 // re-test with interrupt status set
                 thread.interrupt();
@@ -242,7 +242,7 @@ class GetThreadStateTest {
             synchronized (lock) {
                 lock.notifyAll();
                 expected = JVMTI_THREAD_STATE_ALIVE | JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER;
-                check(thread, expected);
+                await(thread, expected);
 
                 // re-test with interrupt status set
                 thread.interrupt();


### PR DESCRIPTION
J9 occassionally takes more time than the test expects to reach `JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER` state.

Grinder 50x passing: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/49862/

Fixes: https://github.com/eclipse-openj9/openj9/issues/21669