### PR TITLE
CRIU calls isTimeCompensationEnabled() to enable time compensation

### DIFF
--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -215,6 +215,7 @@ public class Timer {
         // only tasks scheduled before Checkpoint to be adjusted
         if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
             && (task != null)
+            && InternalCRIUSupport.isTimeCompensationEnabled()
         ) {
             task.criuAdjustRequired = true;
         }
@@ -278,6 +279,7 @@ public class Timer {
         // only tasks scheduled before Checkpoint to be adjusted
         if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
             && (task != null)
+            && InternalCRIUSupport.isTimeCompensationEnabled()
         ) {
             task.criuAdjustRequired = true;
         }
@@ -366,6 +368,7 @@ public class Timer {
         // only tasks scheduled before Checkpoint to be adjusted
         if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
             && (task != null)
+            && InternalCRIUSupport.isTimeCompensationEnabled()
         ) {
             task.criuAdjustRequired = true;
         }


### PR DESCRIPTION
CRIU calls `isTimeCompensationEnabled()` to enable time compensation

The time compensation is disabled if `InternalCRIUSupport.isTimeCompensationEnabled()` returns `false`.

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/996

Signed-off-by: Jason Feng <fengj@ca.ibm.com>