### PR TITLE
Increase time out for java/lang/Thread/virtual/SynchronizedNative.java

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/SynchronizedNative.java
+++ b/test/jdk/java/lang/Thread/virtual/SynchronizedNative.java
@@ -28,7 +28,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/timeout=300 --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -36,7 +36,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm -Xint --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/timeout=300 -Xint --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -44,7 +44,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/timeout=300 -Xcomp -XX:TieredStopAtLevel=1 --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 /*
@@ -52,7 +52,7 @@
  * @requires vm.continuations
  * @modules java.base/java.lang:+open jdk.management
  * @library /test/lib
- * @run junit/othervm -Xcomp -XX:-TieredCompilation --enable-native-access=ALL-UNNAMED SynchronizedNative
+ * @run junit/othervm/timeout=300 -Xcomp -XX:-TieredCompilation --enable-native-access=ALL-UNNAMED SynchronizedNative
  */
 
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
Increase time out for `java/lang/Thread/virtual/SynchronizedNative.java`

Related to 
* https://github.com/eclipse-openj9/openj9/issues/21727

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1001

Signed-off-by: Jason Feng <fengj@ca.ibm.com>