### PR TITLE
Fix cmake warnings related to unused variables

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -257,11 +257,12 @@ CMAKE_ARGS := \
 	-DOMR_MIXED_REFERENCES_MODE=$(OMR_MIXED_REFERENCES_MODE) \
 	-DOPENJ9_BUILD=true \
 	-DOPENJ9_SHA=$(OPENJ9_SHA) \
-	-DOPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
 	#
 
-# Windows can't specify compiler overrides since we already generated wrapper scripts.
-ifneq (windows,$(OPENJDK_TARGET_OS))
+ifeq ($(call isTargetOs, windows), true)
+  CMAKE_ARGS += -DOPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS)
+else
+  # Windows can't specify compiler overrides since we use wrapper scripts.
   # Override the compilers if an OPENJ9_* value is specified.
   # Otherwise, toolchain.cmake has the default values.
   ifneq (,$(OPENJ9_CC))
@@ -295,10 +296,6 @@ endif # OPENJ9_ENABLE_JFR
 
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
   CMAKE_ARGS += -DJ9VM_OPT_JITSERVER=ON
-
-  ifneq (,$(OPENSSL_CFLAGS))
-    CMAKE_ARGS += -DOPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"
-  endif
 
   ifneq (,$(OPENSSL_DIR))
     CMAKE_ARGS += -DOPENSSL_DIR="$(OPENSSL_DIR)"

--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -92,9 +92,10 @@ ifeq (,$(OPENSSL_TARGET))
   $(error Unsupported platform $(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU))
 endif # OPENSSL_TARGET
 
-OPENSSL_CFLAGS :=
 ifeq ($(OPENJDK_TARGET_CPU), s390x)
-  OPENSSL_CFLAGS := -march=z10
+  OPENSSL_CONFIG_CFLAGS := -march=z10
+else
+  OPENSSL_CONFIG_CFLAGS :=
 endif
 
 ifneq (,$(CCACHE))
@@ -106,8 +107,8 @@ ifneq (,$(CCACHE))
 endif # CCACHE
 
 build_openssl :
-	@$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR) for $(OPENSSL_TARGET) with additional CFLAGS $(OPENSSL_CFLAGS)
-	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_CFLAGS) $(OPENSSL_TARGET) shared )
+	@$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR) for $(OPENSSL_TARGET)$(if $(OPENSSL_CONFIG_CFLAGS), with additional CFLAGS $(OPENSSL_CONFIG_CFLAGS))
+	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_CONFIG_CFLAGS) $(OPENSSL_TARGET) shared )
 	$(OPENSSL_PATCH)
 	( $(OPENSSL_MAKE_SETUP) $(CD) $(OPENSSL_DIR) && $(OPENSSL_MAKE) )
 


### PR DESCRIPTION
Newer versions of cmake (e.g. 3.22.1) warn:
```
  Manually-specified variables were not used by the project:
    OPENJDK_VERSION_NUMBER_FOUR_POSITIONS
    OPENSSL_CFLAGS
```
* only specify `OPENJDK_VERSION_NUMBER_FOUR_POSITIONS` on Windows
* remove unused definition of `OPENSSL_CFLAGS`

Adjust OpenSSL build to avoid overwriting `OPENSSL_CFLAGS`.

This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1009.