### PR TITLE
Properly check if jdk.native.openssl.lib property is set

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -112,7 +112,7 @@ public class NativeCrypto {
                     System.err.println("Native crypto library load succeeded - using native crypto library.");
                 }
             } else {
-                if (!nativeLibName.isEmpty()) {
+                if ((nativeLibName != null) && !nativeLibName.isEmpty()) {
                     throw new RuntimeException(nativeLibName + " is not available, crypto libraries are not loaded");
                 }
             }


### PR DESCRIPTION
Whether the property has been set at all needs to be checked before checking if it's not empty.

Related to issue https://github.com/eclipse-openj9/openj9/issues/21867

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1011

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>