### PR TITLE
Use VM.isYieldBlockedVirtualThreadsEnabled() check the legacy lock mode

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java
@@ -30,6 +30,7 @@
 /*
  * @test id=default
  * @summary Verifies JVMTI StopThread support for virtual threads.
+ * @modules java.base/com.ibm.oti.vm
  * @requires vm.continuations
  * @library /test/lib
  * @run main/othervm/native -agentlib:StopThreadTest StopThreadTest
@@ -38,6 +39,7 @@
 /*
  * @test id=platform
  * @summary Verifies JVMTI StopThread support for platform threads.
+ * @modules java.base/com.ibm.oti.vm
  * @library /test/lib
  * @run main/othervm/native -agentlib:StopThreadTest StopThreadTest platform
  */
@@ -276,6 +278,6 @@ public class StopThreadTest {
     }
 
     static boolean preemptableVirtualThread() {
-        return is_virtual && !isBoundVThread;
+        return is_virtual && !isBoundVThread && com.ibm.oti.vm.VM.isYieldBlockedVirtualThreadsEnabled();
     }
 }

--- a/test/jdk/java/lang/Thread/virtual/LockingMode.java
+++ b/test/jdk/java/lang/Thread/virtual/LockingMode.java
@@ -37,6 +37,6 @@ class LockingMode {
      * Returns true if using legacy locking mode.
      */
     static boolean isLegacy() {
-        return true;
+        return !com.ibm.oti.vm.VM.isYieldBlockedVirtualThreadsEnabled();
     }
 }

--- a/test/jdk/java/lang/Thread/virtual/MonitorEnterExit.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorEnterExit.java
@@ -24,7 +24,7 @@
 /*
  * @test id=default
  * @summary Test virtual thread with monitor enter/exit
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -32,7 +32,7 @@
 
 /*
  * @test id=LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -40,7 +40,7 @@
 
 /*
  * @test id=LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -48,7 +48,7 @@
 
 /*
  * @test id=Xint-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xint -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -56,7 +56,7 @@
 
 /*
  * @test id=Xint-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xint -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -64,7 +64,7 @@
 
 /*
  * @test id=Xcomp-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -72,7 +72,7 @@
 
 /*
  * @test id=Xcomp-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -80,7 +80,7 @@
 
 /*
  * @test id=Xcomp-TieredStopAtLevel1-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -88,7 +88,7 @@
 
 /*
  * @test id=Xcomp-TieredStopAtLevel1-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -96,7 +96,7 @@
 
 /*
  * @test id=Xcomp-noTieredCompilation-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorEnterExit
@@ -104,7 +104,7 @@
 
 /*
  * @test id=Xcomp-noTieredCompilation-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorEnterExit


### PR DESCRIPTION
Use `VM.isYieldBlockedVirtualThreadsEnabled()` check the legacy lock mode

The legacy locking mode is enabled if `com.ibm.oti.vm.VM.isYieldBlockedVirtualThreadsEnabled()` returns `false`.

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1013

The PR build doesn't validate the test change.
Verified via [a personal build](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/50383/console)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>