### PR TITLE
Fix error: package com.ibm.oti.vm is not visible

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/MonitorWaitNotify.java
+++ b/test/jdk/java/lang/Thread/virtual/MonitorWaitNotify.java
@@ -20,6 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /*
  * ===========================================================================
  * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
@@ -29,7 +30,7 @@
 /*
  * @test id=default
  * @summary Test virtual threads using Object.wait/notifyAll
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -37,7 +38,7 @@
 
 /*
  * @test id=LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -45,7 +46,7 @@
 
 /*
  * @test id=LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -53,7 +54,7 @@
 
 /*
  * @test id=Xint-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xint -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -61,7 +62,7 @@
 
 /*
  * @test id=Xint-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xint -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -69,7 +70,7 @@
 
 /*
  * @test id=Xcomp-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -77,7 +78,7 @@
 
 /*
  * @test id=Xcomp-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -85,7 +86,7 @@
 
 /*
  * @test id=Xcomp-TieredStopAtLevel1-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -93,7 +94,7 @@
 
 /*
  * @test id=Xcomp-TieredStopAtLevel1-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:TieredStopAtLevel=1 -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -101,7 +102,7 @@
 
 /*
  * @test id=Xcomp-noTieredCompilation-LM_LEGACY
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=1 --enable-native-access=ALL-UNNAMED MonitorWaitNotify
@@ -109,7 +110,7 @@
 
 /*
  * @test id=Xcomp-noTieredCompilation-LM_LIGHTWEIGHT
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:-TieredCompilation -XX:LockingMode=2 --enable-native-access=ALL-UNNAMED MonitorWaitNotify

--- a/test/jdk/java/lang/Thread/virtual/Parking.java
+++ b/test/jdk/java/lang/Thread/virtual/Parking.java
@@ -22,9 +22,15 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test id=default
  * @summary Test virtual threads using park/unpark
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit Parking
@@ -32,7 +38,7 @@
 
 /*
  * @test id=Xint
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xint Parking
@@ -40,7 +46,7 @@
 
 /*
  * @test id=Xcomp
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp Parking
@@ -48,7 +54,7 @@
 
 /*
  * @test id=Xcomp-noTieredCompilation
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -Xcomp -XX:-TieredCompilation Parking

--- a/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
+++ b/test/jdk/java/lang/Thread/virtual/ThreadAPI.java
@@ -22,10 +22,16 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test id=default
  * @bug 8284161 8286788 8321270
  * @summary Test Thread API with virtual threads
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm --enable-native-access=ALL-UNNAMED ThreadAPI
@@ -34,7 +40,7 @@
 /*
  * @test id=no-vmcontinuations
  * @requires vm.continuations
- * @modules java.base/java.lang:+open jdk.management
+ * @modules java.base/com.ibm.oti.vm java.base/java.lang:+open jdk.management
  * @library /test/lib
  * @build LockingMode
  * @run junit/othervm -XX:+UnlockExperimentalVMOptions -XX:-VMContinuations


### PR DESCRIPTION
Fix error: package `com.ibm.oti.vm` is not visible

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1014

This resolves the test compilation error - https://openj9-jenkins.osuosl.org/job/Test_openjdk24_j9_sanity.openjdk_aarch64_linux_Nightly_testList_0/80/consoleFull
```
21:54:31  /home/jenkins/workspace/Test_openjdk24_j9_sanity.openjdk_aarch64_linux_Nightly_testList_0/aqa-tests/openjdk/openjdk-jdk/test/jdk/java/lang/Thread/virtual/LockingMode.java:40: error: package com.ibm.oti.vm is not visible
21:54:31          return !com.ibm.oti.vm.VM.isYieldBlockedVirtualThreadsEnabled();
21:54:31                             ^
21:54:31    (package com.ibm.oti.vm is declared in module java.base, which does not export it to the unnamed module)
```
Verified at [a grinder w/ jdk_lang_0,jdk_lang_j9_0](https://openj9-jenkins.osuosl.org/job/Grinder/lastBuild/console)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>