### PR TITLE
Add key algorithm check for native CBC

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -197,6 +197,9 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
      */
     void init(boolean decrypting, String algorithm, byte[] key, byte[] iv)
             throws InvalidKeyException {
+        if (!algorithm.equalsIgnoreCase("AES") && !algorithm.equalsIgnoreCase("Rijndael")) {
+            throw new InvalidKeyException("Wrong algorithm: AES or Rijndael required");
+        }
 
         if ((key == null) || (iv == null) || (iv.length != blockSize)) {
             throw new InvalidKeyException("Internal error");


### PR DESCRIPTION
Native implementation of CBC mode is used as default while initializing an AES cipher instance. A secret key will be used to initilize an AES cipher instance. However, there is a lack of check to see if the implementation algorithm corresponding to the secret key is consistent with the cipher's algorithm.

This PR solves the issue #21886

Backport from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1016