### PR TITLE
Update NullStringToKey test

### DIFF
--- a/test/jdk/sun/security/krb5/NullStringToKey.java
+++ b/test/jdk/sun/security/krb5/NullStringToKey.java
@@ -21,6 +21,11 @@
  * questions.
  */
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+/*
  * @test
  * @bug 8343622
  * @summary KerberosKey created with null key bytes
@@ -35,8 +40,11 @@ import java.util.List;
 public class NullStringToKey {
     public static void main(String[] args) throws Exception {
 
+        Security.removeProvider("OpenJCEPlus");
+        Security.removeProvider("OpenJCEPlusFIPS");
         Security.removeProvider("SUN");
         Security.removeProvider("SunJCE");
+        Security.removeProvider("SunPKCS11-NSS-FIPS");
 
         var name = new KerberosPrincipal("me@ME.COM");
         var pass = "password".toCharArray();


### PR DESCRIPTION
This is a back-port PR from JDK Next PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1017

The NullStringToKey test attempts to catch the expected IllegalArgumentException by removing the SUN and SunJCE providers. However, the service remains unexpectedly available through SunPKCS11-NSS-FIPS, OpenJCEPlus, and OpenJCEPlusFIPS, causing the test to fail. This update modifies the test to remove these additional providers during execution.

Since this test does not exist in JDK 21 or earlier versions, there is no need to back port it to JDK 21 or earlier versions.