### PR TITLE
Increase Deadlock test timeout for FIPS

### DIFF
--- a/test/jdk/java/security/Security/ClassLoaderDeadlock/Deadlock.sh
+++ b/test/jdk/java/security/Security/ClassLoaderDeadlock/Deadlock.sh
@@ -23,13 +23,16 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
 
 # @test
 # @bug 4944382
 # @summary make sure we do not deadlock loading signed JAR with getInstance()
 # @author Andreas Sterbenz
 # @build Deadlock
-# @run shell/timeout=30 Deadlock.sh
+# @run shell/timeout=60 Deadlock.sh
 
 # set platform-dependent variables
 OS=`uname -s`


### PR DESCRIPTION
Increase `Deadlock` test timeout for FIPS

In weak fips mode `-Dsemeru.fips=true` `-Dsemeru.customprofile=OpenJCEPlusFIPS` there is a bit more processing to
be done during startup to load and read the FIPS profiles from the `java.security` file and setup the JCE algorithms and providers available according to the profile.

Related to 
* https://github.com/eclipse-openj9/openj9/issues/21919

Backported from
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1028

Signed-off-by: Jason Feng <fengj@ca.ibm.com>