### PR TITLE
Revert "Update monitorwaited test to match OpenJ9 impl"

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/MonitorWaited/monitorwaited01/libmonitorwaited01.cpp
@@ -20,11 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
- * ===========================================================================
- */
 
 #include <stdio.h>
 #include <string.h>
@@ -93,11 +88,11 @@ static void check_stack_trace(JNIEnv* jni, jthread thr) {
   err = jvmti->GetStackTrace(thr, 0, MAX_COUNT, frameInfo, &count);
   check_jvmti_status(jni, err, "event handler: error in JVMTI GetStackTrace call");
 
-  const int expected_count = 7;
-  const char* expected_methods[expected_count] = {"wait", "wait", "run", "runWith", "run", "run", "enter"};
+  const int expected_count = 8;
+  const char* expected_methods[expected_count] = {"waitImpl", "wait", "wait", "run", "runWith", "run", "run", "enter"};
 
   if (count != expected_count) {
-    LOG("Expected 7 methods in the stack but found %d", count);
+    LOG("Expected 8 methods in the stack but found %d", count);
     jni->FatalError("Unexpected method count");
   }
 


### PR DESCRIPTION
This reverts commit 7c9ae65e28266c0a93e5a2035b0cf86507072d05.

To accommodate the recent OpenJ9 implementation change
(https://github.com/eclipse-openj9/openj9/pull/21982),
the earlier fix for the `monitorwaited` test is reverted:
https://github.com/ibmruntimes/openj9-openjdk-jdk24/pull/64.

Related: https://github.com/eclipse-openj9/openj9/issues/22031