### PR TITLE
Update Deterministic test to skip OpenJCEPlus

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -832,7 +832,6 @@ sun/security/pkcs12/StorePasswordTest.java https://github.com/eclipse-openj9/ope
 sun/security/pkcs12/StoreSecretKeyTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/StoreTrustedCertTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/WrongPBES2.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/DSA/SecureRandomReset.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/DSA/SupportedDSAParamGen.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/DSA/SupportedDSAParamGenLongKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -872,7 +871,6 @@ sun/security/provider/SecureRandom/StrongSeedReader.java https://github.com/ecli
 sun/security/provider/SeedGenerator/SeedGeneratorChoice.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/X509Factory/BadPem.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/X509Factory/BigCRL.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/certpath/CertId/CheckCertId.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPBuilder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPBuilderWithMD5.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -431,7 +431,6 @@ sun/security/krb5/ktab/BufferBoundary.java https://github.com/eclipse-openj9/ope
 sun/security/krb5/ktab/FileKeyTab.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/krb5/ktab/KeyTabIndex.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/krb5/runNameEquals.sh https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 #
 # Exclude tests list from extended.openjdk
 #
@@ -782,7 +781,6 @@ sun/security/provider/SecureRandom/StrongSeedReader.java https://github.com/ecli
 sun/security/provider/SeedGenerator/SeedGeneratorChoice.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/X509Factory/BadPem.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/X509Factory/BigCRL.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPBuilder.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPBuilderWithMD5.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/certpath/DisabledAlgorithms/CPValidatorEndEntity.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all

--- a/test/jdk/ProblemList-OpenJCEPlus.txt
+++ b/test/jdk/ProblemList-OpenJCEPlus.txt
@@ -31,5 +31,4 @@ java/security/Signature/SignWithOutputBuffer.java https://github.ibm.com/runtime
 javax/crypto/KeyGenerator/CompareKeys.java https://github.ibm.com/runtimes/jit-crypto/issues/779 generic-all
 sun/security/ec/ed/TestEdDSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 sun/security/jca/PreferredProviderNegativeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
-sun/security/provider/all/Deterministic.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 sun/security/provider/DSA/TestMaxLengthDER.java https://github.com/ https://github.ibm.com/runtimes/jit-crypto/issues/780 generic-all

--- a/test/jdk/sun/security/provider/all/Deterministic.java
+++ b/test/jdk/sun/security/provider/all/Deterministic.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8325506
  * @library /test/lib
@@ -62,7 +68,7 @@ public class Deterministic {
 
         for (var p : Security.getProviders()) {
             var name = p.getName();
-            if (name.equals("SunMSCAPI") || name.startsWith("SunPKCS11")) {
+            if (name.equals("SunMSCAPI") || name.startsWith("SunPKCS11") || name.startsWith("OpenJCEPlus")) {
                 System.out.println("Skipped native provider " + name);
                 continue;
             }


### PR DESCRIPTION
The `OpenJCEPlus` is added to the list of native providers to be skipped when this test is run.

The test uses a custom `SecureRandom` instance that is actually deterministic and expects the same result, but this is not applicable in `OpenJCEPlus`, since it uses a native library that utilizes its own source of randomness.

The test is also removed from the various exclusion lists.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1035

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>