### PR TITLE
Update CompareKeys test to skip HKDFGenerator

### DIFF
--- a/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
+++ b/test/jdk/javax/crypto/KeyGenerator/CompareKeys.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.Key;
@@ -126,6 +132,7 @@ public class CompareKeys {
                 // algorithms like RSA.
                 if (s.getType().contains(type)
                         && !((s.getAlgorithm().startsWith("SunTls"))
+                        || s.getAlgorithm().startsWith("kda-hkdf-with-")
                         || s.getProvider().getName().equals("SunMSCAPI"))) {
                     kgs.add(new KeygenAlgo(s.getAlgorithm(), s.getProvider()));
                 }


### PR DESCRIPTION
The `HKDFGenerator` offered by the `OpenJCEPlus` provider is added to the list of `KeyGenerator` instances that need pre-initialization and have to be skipped in this test.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>